### PR TITLE
Improve performance + a small tests + better collision API

### DIFF
--- a/cotix/_abstract_shapes.py
+++ b/cotix/_abstract_shapes.py
@@ -33,7 +33,7 @@ class AbstractShape(eqx.Module, strict=True):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _get_center(self):
+    def get_center(self):
         """
         Returns an approximate central point of the shape. It is computed as middle of
         an axis-aligned bounding box.

--- a/cotix/_convex_shapes.py
+++ b/cotix/_convex_shapes.py
@@ -15,7 +15,7 @@ class Circle(AbstractConvexShape, strict=True):
         normalized_direction = direction / jnp.linalg.norm(direction)
         return normalized_direction * self.radius + self.position
 
-    def _get_center(self):
+    def get_center(self):
         return self.position
 
 
@@ -32,7 +32,7 @@ class Polygon(AbstractConvexShape, strict=True):
         dot_products = jax.lax.map(lambda x: jnp.dot(x, direction), self.vertices)
         return self.vertices.at[jnp.argmax(dot_products)].get()
 
-    def _get_center(self) -> Float[Array, "2"]:
+    def get_center(self) -> Float[Array, "2"]:
         return jnp.mean(self.vertices, axis=0)
 
 
@@ -56,5 +56,5 @@ class AABB(AbstractConvexShape, strict=True):
         support_point = jnp.where(direction >= 0, self.max, self.min)
         return support_point
 
-    def _get_center(self):
+    def get_center(self):
         return (self.min + self.max) / 2.0

--- a/cotix/_universal_shape.py
+++ b/cotix/_universal_shape.py
@@ -82,7 +82,7 @@ class UniversalShape(eqx.Module, strict=True):
             solver_iterations,
         )
 
-    def _get_center(self):
+    def get_center(self):
         return jtu.tree_reduce(
             lambda acc, shape: acc + shape.get_center(),
             self.parts,

--- a/test/test_shapes.py
+++ b/test/test_shapes.py
@@ -17,7 +17,7 @@ def test_rect_support_vectors():
             dtype=jnp.float32,
         )
     )
-    assert jnp.all(rect1._get_center() == jnp.array([0, 0]))
+    assert jnp.all(rect1.get_center() == jnp.array([0.0, 0.0]))
     assert rect1.get_support(jnp.array([1.0, 0.0]))[0] == 1
 
     rect2 = Polygon(
@@ -31,7 +31,7 @@ def test_rect_support_vectors():
             dtype=jnp.float32,
         )
     )
-    assert jnp.all(rect2._get_center() == jnp.array([1.5, 1.5]))
+    assert jnp.all(rect2.get_center() == jnp.array([1.5, 1.5]))
     assert rect2.get_support(jnp.array([1.0, 0.0]))[0] == 2
     assert rect2.get_support(jnp.array([0.0, -1.0]))[1] == 1
 


### PR DESCRIPTION
@mikhail-vlasenko take a look, I changed an API a bit (again). Now convex collision resolution admits two optional parameters: key and direction, for possibly faster convergence of EPA/GJK. 
