### PR TITLE
16 angular momentum and friction

### DIFF
--- a/cotix/_bodies.py
+++ b/cotix/_bodies.py
@@ -30,6 +30,7 @@ class AbstractBody(eqx.Module, strict=True):
     angular_velocity: AbstractVar[Float[Array, ""]]
 
     elasticity: AbstractVar[Float[Array, ""]]
+    friction_coefficient: AbstractVar[Float[Array, ""]]
 
     shape: AbstractVar[UniversalShape]
 
@@ -121,6 +122,7 @@ class Ball(AbstractBody, strict=True):
     angular_velocity: Float[Array, ""]
 
     elasticity: Float[Array, ""]
+    friction_coefficient: Float[Array, ""]
 
     shape: UniversalShape
 
@@ -141,6 +143,7 @@ class Ball(AbstractBody, strict=True):
         self.angular_velocity = jnp.array(0.0)
 
         self.elasticity = jnp.array(1.0)
+        self.friction_coefficient = jnp.array(1.0)
 
         self.shape = shape
         self.shape = self.shape.update_transform(
@@ -185,6 +188,7 @@ class AnyBody(AbstractBody, strict=True):
     angular_velocity: Float[Array, ""]
 
     elasticity: Float[Array, ""]
+    friction_coefficient: Float[Array, ""]
 
     shape: UniversalShape
 
@@ -197,6 +201,7 @@ class AnyBody(AbstractBody, strict=True):
         angle,
         angular_velocity,
         elasticity,
+        friction_coefficient,
         shape,
     ):
         self.mass = mass
@@ -209,6 +214,7 @@ class AnyBody(AbstractBody, strict=True):
         self.angular_velocity = angular_velocity
 
         self.elasticity = elasticity
+        self.friction_coefficient = friction_coefficient
 
         self.shape = shape
         self.shape = self.shape.update_transform(

--- a/cotix/_bodies.py
+++ b/cotix/_bodies.py
@@ -125,7 +125,7 @@ class Ball(AbstractBody, strict=True):
     shape: UniversalShape
 
     def __init__(self, mass, position, velocity, shape):
-        # check that the shape is a circle here
+        # check that the shape is a circle
         if not (isinstance(shape.parts[0], Circle) and len(shape.parts) == 1):
             raise ValueError("Ball universal shape must be a circle")
 
@@ -155,6 +155,7 @@ class Ball(AbstractBody, strict=True):
         ball = Ball(
             jnp.array(1.0),
             jnp.zeros((2,)),
+            jnp.zeros((2,)),
             UniversalShape(Circle(jnp.array(0.05), jnp.zeros((2,)))),
         )
         ball = (
@@ -167,3 +168,49 @@ class Ball(AbstractBody, strict=True):
             .set_shape(UniversalShape(Circle(jnp.array(0.05), jnp.zeros((2,)))))
         )
         return ball
+
+
+class AnyBody(AbstractBody, strict=True):
+    """
+    A body with any shape. Useful for tests.
+    """
+
+    mass: Float[Array, ""]
+    inertia: Float[Array, ""]
+
+    position: Float[Array, "2"]
+    velocity: Float[Array, "2"]
+
+    angle: Float[Array, ""]
+    angular_velocity: Float[Array, ""]
+
+    elasticity: Float[Array, ""]
+
+    shape: UniversalShape
+
+    def __init__(
+        self,
+        mass,
+        inertia,
+        position,
+        velocity,
+        angle,
+        angular_velocity,
+        elasticity,
+        shape,
+    ):
+        self.mass = mass
+        self.inertia = inertia
+
+        self.position = position
+        self.velocity = velocity
+
+        self.angle = angle
+        self.angular_velocity = angular_velocity
+
+        self.elasticity = elasticity
+
+        self.shape = shape
+        self.shape = self.shape.update_transform(
+            angle=self.angle, position=self.position
+        )

--- a/cotix/_bodies.py
+++ b/cotix/_bodies.py
@@ -29,6 +29,8 @@ class AbstractBody(eqx.Module, strict=True):
     angle: AbstractVar[Float[Array, ""]]
     angular_velocity: AbstractVar[Float[Array, ""]]
 
+    elasticity: AbstractVar[Float[Array, ""]]
+
     shape: AbstractVar[UniversalShape]
 
     def update_transform(self):
@@ -76,6 +78,13 @@ class AbstractBody(eqx.Module, strict=True):
         """Replaces the shape with any other shape: not recommended to use."""
         return eqx.tree_at(lambda x: x.shape, self, shape)
 
+    def get_center_of_mass(self):
+        return self.position
+
+    def get_mass_matrix(self):
+        # it is a scalar since we are in 2d, so there is 1 axis of rotation
+        return self.inertia
+
     def __invariant__(self):
         return (
             # Checks for nans
@@ -109,6 +118,8 @@ class Ball(AbstractBody, strict=True):
     angle: Float[Array, ""]
     angular_velocity: Float[Array, ""]
 
+    elasticity: Float[Array, ""]
+
     shape: UniversalShape
 
     def __init__(self, mass, velocity, shape):
@@ -120,6 +131,8 @@ class Ball(AbstractBody, strict=True):
 
         self.angle = jnp.array(0.0)
         self.angular_velocity = jnp.array(0.0)
+
+        self.elasticity = jnp.array(1.0)
 
         self.shape = shape
 

--- a/cotix/_collision_resolution.py
+++ b/cotix/_collision_resolution.py
@@ -27,6 +27,10 @@ class ContactInfo(eqx.Module):
 
 
 class CollisionResolutionExtraInfo(eqx.Module):
+    """
+    Additional information about the collision that is returned by _resolve_collision()
+    """
+
     lever_arm1: Float[Array, ""]
     lever_arm2: Float[Array, ""]
     tangential_relative_velocity: Float[Array, ""]

--- a/cotix/_collision_resolution.py
+++ b/cotix/_collision_resolution.py
@@ -179,10 +179,7 @@ def _resolve_collision(
     col_impulse = -jnp.array([primary_col_impulse, friction_impulse])
 
     # jax.debug.print(
-    #     "\nrelative_contact_points: "
-    #     "{relative_contact_point1}, {relative_contact_point2}. "
-    #     "perpendicular: {perpendicular}, "
-    #     "lever arms: {lever_arm1}, {lever_arm2}. \n"
+    #     "\nlever arms: {lever_arm1}, {lever_arm2}. \n"
     #     "center1: {center1}, center2: {center2}. "
     #     "contact_point: {contact_point}. \n"
     #     "global_supports {sup1}, {sup2}. "
@@ -191,14 +188,11 @@ def _resolve_collision(
     #     "friction_impulse: {friction_impulse}. \n"
     #     "col_impulse in new basis: {col_impulse}. \n"
     #     "col_impulse original: {col_impulse_original}. \n",
-    #     relative_contact_point1=relative_contact_point1,
-    #     relative_contact_point2=relative_contact_point2,
-    #     perpendicular=perpendicular_new_basis,
     #     lever_arm1=lever_arm1,
     #     lever_arm2=lever_arm2,
     #     center1=body1.get_center_of_mass(),
     #     center2=body2.get_center_of_mass(),
-    #     contact_point=change_of_basis_inv @ contact_point,
+    #     contact_point=contact_point,
     #     sup1=body1.shape.get_global_support(-unit_collision_vector),
     #     sup2=body2.shape.get_global_support(unit_collision_vector),
     #     unit_collision_vector=unit_collision_vector,
@@ -219,7 +213,7 @@ def _resolve_collision(
     )
     body2 = body2.set_angular_velocity(
         body2.angular_velocity
-        - (lever_arm2 * col_impulse[0]) / body2.inertia
+        + (lever_arm2 * col_impulse[0]) / body2.inertia
         - col_impulse[1] / body2.inertia
     )
     # the col_impulse[1] is applied with the same sign to both bodies.

--- a/cotix/_collision_resolution.py
+++ b/cotix/_collision_resolution.py
@@ -19,7 +19,7 @@ def _split_bodies(
     # it may be not good idea to split 100% of the penetration,
     #   but we can change that later
     split_portion = 1.0
-    # lets apply translation to both bodies, taking their mass into account
+    # let's apply translation to both bodies, taking their mass into account
     body1 = body1.set_position(
         body1.position
         + split_portion * epa_vector * (body2.mass / (body1.mass + body2.mass))
@@ -67,8 +67,8 @@ def _resolve_collision(
     # get_global_support doesnt know about the new basis,
     # so we use a vector from the old basis
     contact_point = (
-        body1.shape.get_global_support(unit_collision_vector)
-        + body2.shape.get_global_support(-unit_collision_vector)
+        body1.shape.get_global_support(-unit_collision_vector)
+        + body2.shape.get_global_support(unit_collision_vector)
     ) / 2
     contact_point = change_of_basis @ contact_point
 
@@ -83,10 +83,10 @@ def _resolve_collision(
     lever_arm2 = jnp.dot(relative_contact_point2, perpendicular_new_basis)
 
     # jax.debug.print(
-    #     "relative_contact_points: "
+    #     "\nrelative_contact_points: "
     #     "{relative_contact_point1}, {relative_contact_point2}. "
     #     "perpendicular: {perpendicular}, "
-    #     "arms: {lever_arm1}, {lever_arm2}. \n"
+    #     "lever arms: {lever_arm1}, {lever_arm2}. \n"
     #     "center1: {center1}, center2: {center2}. "
     #     "contact_point: {contact_point}. \n"
     #     "global_supports {sup1}, {sup2}. "
@@ -99,8 +99,8 @@ def _resolve_collision(
     #     center1=body1.get_center_of_mass(),
     #     center2=body2.get_center_of_mass(),
     #     contact_point=change_of_basis_inv @ contact_point,
-    #     sup1=body1.shape.get_global_support(unit_collision_vector),
-    #     sup2=body2.shape.get_global_support(-unit_collision_vector),
+    #     sup1=body1.shape.get_global_support(-unit_collision_vector),
+    #     sup2=body2.shape.get_global_support(unit_collision_vector),
     #     unit_collision_vector=unit_collision_vector,
     # )
 

--- a/cotix/_geometry_utils.py
+++ b/cotix/_geometry_utils.py
@@ -77,7 +77,13 @@ def perpendicular_vector(v):
     return jnp.array([-v[1], v[0]])
 
 
-class HomogenuousTransformer(eqx.Module, strict=True):
+def angle_between(v1, v2):
+    v1_u = v1 / jnp.linalg.norm(v1)
+    v2_u = v2 / jnp.linalg.norm(v2)
+    return jnp.arccos(jnp.clip(jnp.dot(v1_u, v2_u), -1.0, 1.0))
+
+
+class HomogeneousTransformer(eqx.Module, strict=True):
     """
     Allows to apply arbitrary affine transformations to passed vectors/directions
     """

--- a/cotix/_universal_shape.py
+++ b/cotix/_universal_shape.py
@@ -9,7 +9,7 @@ from jaxtyping import Array, Float
 
 from ._abstract_shapes import AbstractShape, SupportFn
 from ._collisions import check_for_collision_convex, compute_penetration_vector_convex
-from ._geometry_utils import HomogenuousTransformer
+from ._geometry_utils import HomogeneousTransformer
 
 
 class UniversalShape(eqx.Module, strict=True):
@@ -22,11 +22,11 @@ class UniversalShape(eqx.Module, strict=True):
     """
 
     parts: list[AbstractShape]
-    _transformer: HomogenuousTransformer
+    _transformer: HomogeneousTransformer
 
     def __init__(self, *shapes: AbstractShape):
         self.parts = [*shapes]
-        self._transformer = HomogenuousTransformer()
+        self._transformer = HomogeneousTransformer()
 
     def wrap_local_support(self, support_fn: SupportFn) -> SupportFn:
         """
@@ -63,7 +63,7 @@ class UniversalShape(eqx.Module, strict=True):
         return eqx.tree_at(
             lambda x: x._transformer,
             self,
-            HomogenuousTransformer(angle=angle, position=position),
+            HomogeneousTransformer(angle=angle, position=position),
         )
 
     def collides_with(self, other):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 urls = {repository = "https://github.com/DelftMercurians/cotix" }
-dependencies = ["beartype>=0.16.3", "typing_extensions>=3.7.4.1", "jax>=0.4.18", "jaxlib>=0.4.18", "jaxtyping>=0.2.23", "equinox>=0.11.1"]
+dependencies = ["beartype>=0.16.3", "typing_extensions>=3.7.4.1", "jax>=0.4.18", "jaxlib>=0.4.18", "jaxtyping>=0.2.23", "equinox>=0.11.1", "pytest-check>=2.2.2"]
 
 [build-system]
 requires = ["hatchling"]

--- a/test/test_collision_resolution.py
+++ b/test/test_collision_resolution.py
@@ -70,16 +70,21 @@ def test_circle_hits_circle_elastic():
             ~res_collision,
             jnp.linalg.norm(penetration2) < 1e-3 * jnp.linalg.norm(penetration1),
         )
-        # wither the collision was resolved, or the balls are moving apart
+        # either the collision was resolved, or the balls are moving apart
         return (
-            v1_away
-            & v2_away
-            & res_first_collision
-            & (jnp.logical_xor(no_collision, moving_apart))
+            (v1_away & v2_away),
+            res_first_collision,
+            jnp.logical_xor(no_collision, moving_apart),
         )
 
     N = 1000
     f = jax.vmap(f)
-    out = f(jr.split(key, N))
+    velocities_away, was_collision, collision_resolved_xor_didnt_have_to_be = f(
+        jr.split(key, N)
+    )
 
-    assert jnp.all(out)
+    assert jnp.all(was_collision), "there wasnt a collision"
+    assert jnp.all(velocities_away), "velocities arent away"
+    assert jnp.all(
+        collision_resolved_xor_didnt_have_to_be
+    ), "collision was not resolved, or was resolved unnecessarily"

--- a/test/test_collision_resolution.py
+++ b/test/test_collision_resolution.py
@@ -450,8 +450,8 @@ def test_friction_affects_center_of_mass_velocity():
         no_collision,
         penetration_before,
         penetration_after,
-        body1,
-        body2,
+        updated_body1,
+        updated_body2,
     ) = _collision_resolution_helper(body1, body2, contact_point)
 
     with check:
@@ -461,15 +461,17 @@ def test_friction_affects_center_of_mass_velocity():
 
     # ball is going to the right, because of its spin
     with check:
-        assert body1.velocity[0] > 0, "velocity of the ball is not to the right"
+        assert updated_body1.velocity[0] > 0, "velocity of the ball is not to the right"
 
     # triangle is spun counterclockwise and pushed left by the ball's rotation
     with check:
-        assert body2.velocity[0] < 0, "velocity of the triangle is not to the left"
-        assert body2.velocity[1] < 0, "velocity of the triangle is not down"
+        assert (
+            updated_body2.velocity[0] < 0
+        ), "velocity of the triangle is not to the left"
+        assert updated_body2.velocity[1] < 0, "velocity of the triangle is not down"
     with check:
-        assert abs(body2.angular_velocity) > 1e-2, "triangle was not spun"
-        assert body2.angular_velocity > 0, (
+        assert abs(updated_body2.angular_velocity) > 1e-2, "triangle was not spun"
+        assert updated_body2.angular_velocity > 0, (
             "angular velocity of the triangle is not positive. "
             "by convention, it should be positive "
             "if the triangle is rotating counterclockwise"
@@ -477,9 +479,23 @@ def test_friction_affects_center_of_mass_velocity():
 
     with check:
         # ball should continue spinning, but slower
-        assert abs(body1.angular_velocity) < abs(
+        assert abs(updated_body1.angular_velocity) < abs(
             initial_angular_v
         ), "the ball's angular velocity should decrease"
-        assert jnp.sign(body1.angular_velocity) == jnp.sign(
+        assert jnp.sign(updated_body1.angular_velocity) == jnp.sign(
             initial_angular_v
         ), "the ball should keep rotating in the same direction"
+
+    # test that switching the order of bodies doesnt change the result
+    (
+        velocities_away,
+        res_first_collision,
+        no_collision,
+        penetration_before,
+        penetration_after,
+        reversed_body1,
+        reversed_body2,
+    ) = _collision_resolution_helper(body2, body1, contact_point)
+    with check:
+        assert reversed_body1 == updated_body2, "order of bodies matters"
+        assert reversed_body2 == updated_body1, "order of bodies matters"

--- a/test/test_collision_resolution.py
+++ b/test/test_collision_resolution.py
@@ -202,13 +202,22 @@ def test_triangle_circle_angular():
     )
 
     # velocities are such that the distance between the shapes is increasing
-    (jnp.dot(body1.velocity - body2.velocity, body1.position - body2.position) >= 0)
-    jnp.logical_or(
+    velocities_away = (
+        jnp.dot(body1.velocity - body2.velocity, body1.position - body2.position) >= 0
+    )
+    no_collision = jnp.logical_or(
         ~res_collision,
         jnp.linalg.norm(penetration_after) < 1e-3 * jnp.linalg.norm(penetration_before),
     )
 
-    angle_between(v1, -penetration_before)
+    epa_velocity_angle = angle_between(v1, -penetration_before)
+
+    print(
+        velocities_away
+        & res_first_collision
+        & no_collision
+        & (epa_velocity_angle < 1e-3)
+    )
 
     # assert (
     #     epa_velocity_angle < 1e-3

--- a/test/test_collision_resolution.py
+++ b/test/test_collision_resolution.py
@@ -3,7 +3,7 @@ from jax import numpy as jnp, random as jr
 from pytest_check import check  # for possible multiple assert failures
 
 from cotix._bodies import AnyBody, Ball
-from cotix._collision_resolution import _resolve_collision_checked, ContactInfo
+from cotix._collision_resolution import _resolve_collision, ContactInfo
 from cotix._collisions import (
     check_for_collision_convex,
     compute_penetration_vector_convex,
@@ -35,7 +35,7 @@ def _collision_resolution_helper(body1, body2, contact_point=None):
 
     contact_info = ContactInfo(penetration_before, contact_point)
 
-    body1, body2, extra_info = _resolve_collision_checked(body1, body2, contact_info)
+    body1, body2, extra_info = _resolve_collision(body1, body2, contact_info)
 
     # test get global support
     res_collision, simplex = check_for_collision_convex(

--- a/test/test_collisions.py
+++ b/test/test_collisions.py
@@ -8,6 +8,7 @@ from cotix._collisions import (
     compute_penetration_vector_convex,
 )
 from cotix._convex_shapes import AABB, Circle, Polygon
+from cotix._geometry_utils import angle_between
 from cotix._universal_shape import UniversalShape
 
 
@@ -235,11 +236,6 @@ def test_circle_vs_circle_epa_direction():
             a.get_support, b.get_support, simplex
         )
 
-        def angle_between(v1, v2):
-            v1_u = v1 / jnp.linalg.norm(v1)
-            v2_u = v2 / jnp.linalg.norm(v2)
-            return jnp.arccos(jnp.clip(jnp.dot(v1_u, v2_u), -1.0, 1.0))
-
         def _c1(_):
             return true_no_collision == res_no_collision
 
@@ -295,11 +291,6 @@ def test_ball_vs_ball_epa_direction():
         epa_vector = compute_penetration_vector_convex(
             body1.shape.get_global_support, body2.shape.get_global_support, simplex
         )
-
-        def angle_between(v1, v2):
-            v1_u = v1 / jnp.linalg.norm(v1)
-            v2_u = v2 / jnp.linalg.norm(v2)
-            return jnp.arccos(jnp.clip(jnp.dot(v1_u, v2_u), -1.0, 1.0))
 
         def _c1(_):
             return true_no_collision == res_no_collision

--- a/test/test_collisions.py
+++ b/test/test_collisions.py
@@ -2,11 +2,13 @@ import jax
 import pytest
 from jax import numpy as jnp, random as jr
 
+from cotix._bodies import Ball
 from cotix._collisions import (
     check_for_collision_convex,
     compute_penetration_vector_convex,
 )
 from cotix._convex_shapes import AABB, Circle, Polygon
+from cotix._universal_shape import UniversalShape
 
 
 def test_circle_vs_circle():
@@ -203,3 +205,118 @@ def test_circle_circle_aligned_positive(pos):
     )
 
     assert jnp.linalg.norm(penetration - jnp.array(pos) * 0.2) < 1e-3
+
+
+def test_circle_vs_circle_epa_direction():
+    key = jr.PRNGKey(0)
+    jr.PRNGKey(3)
+
+    def f(key):
+        key1, key2, key3, key4 = jr.split(key, 4)
+        pa = jr.uniform(key1, (2,)) * 4 - 2
+        pb = jr.uniform(key2, (2,)) * 4 - 2
+        dist = jnp.sqrt(jnp.sum((pa - pb) ** 2))
+        ra = jr.uniform(key3, minval=dist * 0.25, maxval=dist * 0.75)
+        # guarantee a collision
+        rb = jr.uniform(key4, minval=(dist - ra) * 1.05, maxval=(dist - ra) * 1.15)
+
+        a = Circle(ra, pa)
+        b = Circle(rb, pb)
+
+        true_no_collision = jnp.sum((pa - pb) ** 2) > (ra + rb) ** 2
+        -jnp.sqrt(jnp.sum((pa - pb) ** 2)) + (ra + rb)
+
+        dir = b.get_center() - a.get_center()
+        res_collision, simplex = check_for_collision_convex(
+            a.get_support, b.get_support, dir
+        )
+        res_no_collision = ~res_collision
+        epa_vector = compute_penetration_vector_convex(
+            a.get_support, b.get_support, simplex
+        )
+
+        def angle_between(v1, v2):
+            v1_u = v1 / jnp.linalg.norm(v1)
+            v2_u = v2 / jnp.linalg.norm(v2)
+            return jnp.arccos(jnp.clip(jnp.dot(v1_u, v2_u), -1.0, 1.0))
+
+        def _c1(_):
+            return true_no_collision == res_no_collision
+
+        def _c2(pa):
+            first_cond = true_no_collision == res_no_collision
+
+            # second condition is that epa vector is in the right direction
+            second_cond = angle_between(epa_vector, pa - pb) < 1e-2
+            return first_cond & second_cond
+
+        return jax.lax.cond(true_no_collision, _c1, _c2, pa)
+
+    N = 10000
+    keys = jr.split(key, N)
+    f = jax.jit(jax.vmap(f))
+    out = f(keys)
+    if not jnp.all(out):
+        print(f"failed: {jnp.sum(~out) / N}")
+    assert jnp.all(out)
+
+
+def test_ball_vs_ball_epa_direction():
+    key = jr.PRNGKey(0)
+    jr.PRNGKey(3)
+
+    def f(key):
+        key1, key2, key3, key4 = jr.split(key, 4)
+        pa = jr.uniform(key1, (2,)) * 4 - 2
+        pb = jr.uniform(key2, (2,)) * 4 - 2
+        dist = jnp.sqrt(jnp.sum((pa - pb) ** 2))
+        ra = jr.uniform(key3, minval=dist * 0.25, maxval=dist * 0.75)
+        # guarantee a collision
+        rb = jr.uniform(key4, minval=(dist - ra) * 1.05, maxval=(dist - ra) * 1.15)
+
+        zero_position = jnp.zeros((2,))
+        shape1 = Circle(ra, zero_position)
+        shape2 = Circle(rb, zero_position)
+
+        true_no_collision = jnp.sum((pa - pb) ** 2) > (ra + rb) ** 2
+        -jnp.sqrt(jnp.sum((pa - pb) ** 2)) + (ra + rb)
+
+        body1 = Ball(jnp.array(1.0), pa, jnp.zeros((2,)), UniversalShape(shape1))
+        body2 = Ball(jnp.array(1.0), pb, jnp.zeros((2,)), UniversalShape(shape2))
+
+        body1.shape.wrap_local_support(body1.shape.parts[0].get_support)
+        body2.shape.wrap_local_support(body2.shape.parts[0].get_support)
+
+        dir = pb - pa
+        res_collision, simplex = check_for_collision_convex(
+            body1.shape.get_global_support, body2.shape.get_global_support, dir
+        )
+        res_no_collision = ~res_collision
+        epa_vector = compute_penetration_vector_convex(
+            body1.shape.get_global_support, body2.shape.get_global_support, simplex
+        )
+
+        def angle_between(v1, v2):
+            v1_u = v1 / jnp.linalg.norm(v1)
+            v2_u = v2 / jnp.linalg.norm(v2)
+            return jnp.arccos(jnp.clip(jnp.dot(v1_u, v2_u), -1.0, 1.0))
+
+        def _c1(_):
+            return true_no_collision == res_no_collision
+
+        def _c2(pa):
+            first_cond = true_no_collision == res_no_collision
+
+            # second condition is that epa vector is in the right direction
+            second_cond = angle_between(epa_vector, pa - pb) < 1e-2
+            return first_cond & second_cond
+
+        return jax.lax.cond(true_no_collision, _c1, _c2, pa)
+
+    N = 10000
+    keys = jr.split(key, N)
+    f = jax.jit(jax.vmap(f))
+    out = f(keys)
+    if not jnp.all(out):
+        print(f"failed: {jnp.sum(~out) / N}")
+    assert jnp.all(out)


### PR DESCRIPTION
This pull request introduces a series of updates aimed at improving the collision resolution logic within the system. Below is a summary of the key changes:

#### Added
- Implementation of angular momentum from impact in collision resolution.
- Implementation of angular momentum from friction in collision resolution.
- Plenty of new tests for collision resolution.
- Some new tests for collision detection.

#### Fixed
- Added ContactInfo class; contact point is now expected by the `_resolve_collision` method within ContactInfo.
- Fixed velocities_away checks.

#### Improved
- ExtraInfo is returned by collision resolution at the third position. It is useful for test and potentially elsewhere
- Introduced a much of complex, but not randomized tests to further validate the robustness of the collision resolution.
- Added `pytest-check` as a dependency, allowing the visibility of multiple failing asserts during test runs.
- Docstrings
- Corrected spelling in `HomogeneousTransformer`
